### PR TITLE
add support for `.` current path

### DIFF
--- a/helloWorld.mel
+++ b/helloWorld.mel
@@ -332,8 +332,8 @@ global proc installModule()
         print("Content:\n");
         for($line in $moduleContent){
             string $processedLine = `substitute "<PATH>" $line $path`;
-            if (endsWith($line, ".\r"))
-                $processedLine = `substring $line 1 (size($line) - 2)` + $path + "\r";
+            if (endsWith($line, ".\r") || endsWith($line, "."))
+                $processedLine = `substring $line 1 (size($line) - 2)` + " " + $path + "\r";
             print("    " + $processedLine + "\n");
             fprint $fileId ($processedLine + "\n");  
         }

--- a/helloWorld.mel
+++ b/helloWorld.mel
@@ -332,6 +332,8 @@ global proc installModule()
         print("Content:\n");
         for($line in $moduleContent){
             string $processedLine = `substitute "<PATH>" $line $path`;
+            if (endsWith($line, ".\r"))
+                $processedLine = `substring $line 1 (size($line) - 2)` + $path + "\r";
             print("    " + $processedLine + "\n");
             fprint $fileId ($processedLine + "\n");  
         }


### PR DESCRIPTION
add `.` support so that the mod file still can work with maya environment variable `MAYA_MODULE_PATH`